### PR TITLE
Add landing and login pages

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,11 +1,7 @@
-from views import whatsapp
-from views import sheets
-from views import home
-from views import docs
+from views import whatsapp, sheets, home, docs, landing, login
 import streamlit as st
 import locale
 import warnings
-
 
 try:
     locale.setlocale(locale.LC_ALL, 'pt_BR.UTF-8')
@@ -15,7 +11,6 @@ except locale.Error:
         locale.setlocale(locale.LC_ALL, "")
     except locale.Error:
         pass
-
 
 PAGES = [
     {
@@ -47,6 +42,20 @@ def main():
         page_icon="title",
         layout="wide"
     )
+
+    if 'page_state' not in st.session_state:
+        st.session_state.page_state = 'landing'
+        st.session_state.logged_in = False
+
+    if st.session_state.page_state == 'landing':
+        landing.render()
+        return
+
+    if not st.session_state.logged_in:
+        st.session_state.page_state = 'login'
+        login.render()
+        return
+
     selected = st.navigation(
         [
             st.Page(

--- a/views/landing.py
+++ b/views/landing.py
@@ -1,0 +1,65 @@
+import streamlit as st
+import base64
+from pathlib import Path
+
+@st.fragment
+def render():
+    logo_path = Path("assets/toledo.png")
+    logo_b64 = base64.b64encode(logo_path.read_bytes()).decode() if logo_path.exists() else ""
+
+    st.markdown(
+        """
+        <style>
+        .landing-container {
+            display: flex;
+            flex-direction: column;
+            justify-content: center;
+            align-items: center;
+            min-height: 90vh;
+            text-align: center;
+            background: linear-gradient(-45deg, #1e3a8a, #1e293b, #3b82f6, #1e40af);
+            background-size: 300% 300%;
+            animation: gradient 8s ease infinite;
+        }
+        @keyframes gradient {
+            0% {background-position: 0% 50%;}
+            50% {background-position: 100% 50%;}
+            100% {background-position: 0% 50%;}
+        }
+        .landing-container img {
+            width: 180px;
+            border-radius: 50%;
+            box-shadow: 0 8px 30px rgba(0,0,0,0.3);
+        }
+        .landing-container h1 {
+            color: #ffffff;
+            font-size: 2.5rem;
+            font-family: 'Montserrat', sans-serif;
+            margin: 20px 0 40px 0;
+        }
+        .stButton>button {
+            background-color: #3b82f6;
+            color: #ffffff;
+            padding: 0.6rem 2rem;
+            font-size: 1.1rem;
+            border-radius: 8px;
+            border: none;
+        }
+        </style>
+        """,
+        unsafe_allow_html=True,
+    )
+
+    st.markdown(
+        f"""
+        <div class="landing-container">
+            {'<img src="data:image/png;base64,'+logo_b64+'" />' if logo_b64 else ''}
+            <h1>Toledo Consultoria</h1>
+        </div>
+        """,
+        unsafe_allow_html=True,
+    )
+
+    if st.button("Entrar"):
+        st.session_state.page_state = "login"
+        st.rerun()

--- a/views/login.py
+++ b/views/login.py
@@ -1,0 +1,69 @@
+import streamlit as st
+import base64
+from pathlib import Path
+
+USERNAME = "welton_toledo"
+PASSWORD = "V7#pL9$wXz!F3qRt"
+
+@st.fragment
+def render():
+    logo_path = Path("assets/toledo.png")
+    logo_b64 = base64.b64encode(logo_path.read_bytes()).decode() if logo_path.exists() else ""
+
+    st.markdown(
+        """
+        <style>
+        .login-container {
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+            justify-content: center;
+            min-height: 80vh;
+            text-align: center;
+        }
+        .login-container img {
+            width: 140px;
+            border-radius: 50%;
+            box-shadow: 0 6px 20px rgba(0,0,0,0.3);
+            margin-bottom: 20px;
+        }
+        .stButton>button {
+            background-color: #3b82f6;
+            color: #ffffff;
+            padding: 0.5rem 1.8rem;
+            font-size: 1.05rem;
+            border-radius: 8px;
+            border: none;
+        }
+        </style>
+        """,
+        unsafe_allow_html=True,
+    )
+
+    st.markdown(
+        f"""
+        <div class="login-container">
+            {'<img src="data:image/png;base64,'+logo_b64+'" />' if logo_b64 else ''}
+            <h2>Área Restrita</h2>
+        </div>
+        """,
+        unsafe_allow_html=True,
+    )
+
+    with st.form("login_form"):
+        user = st.text_input("Usuário")
+        pwd = st.text_input("Senha", type="password")
+        submit = st.form_submit_button("Entrar")
+
+    if submit:
+        if user == USERNAME and pwd == PASSWORD:
+            st.session_state.logged_in = True
+            st.session_state.page_state = "app"
+            st.success("Login realizado com sucesso!")
+            st.rerun()
+        else:
+            st.error("Usuário ou senha inválidos.")
+
+    if st.button("Voltar"):
+        st.session_state.page_state = "landing"
+        st.rerun()


### PR DESCRIPTION
## Summary
- add animated landing page
- add login page with static credentials
- gate application pages behind login

## Testing
- `python -m py_compile app.py views/*.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6877e886c824832482438545264f204f